### PR TITLE
Lizard-auth-client to 0.5.2 (=production checkout plus Django 1.5 fix), ...

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,10 +10,12 @@ Changelog of ddsc-api
   incompatible with django-staticfiles, which is a requirement of
   lizard-ui.
 
-- Upgraded lizard-wms and lizard-maptree to versions compatible with
-  Django 1.5.4.
+- Upgraded lizard-wms, lizard-auth-client and lizard-maptree to
+  versions compatible with Django 1.5.4.
 
 - Pinned dependencies to versions currently used in production.
+
+- Small changes to deal with the Django version update.
 
 
 0.4 (2012-11-16)

--- a/ddsc_api/urls.py
+++ b/ddsc_api/urls.py
@@ -3,8 +3,9 @@ from django.conf.urls.defaults import include
 from django.conf.urls.defaults import patterns
 from django.conf.urls.defaults import url
 from django.contrib import admin
-from django.views.generic.simple import redirect_to
+from django.views.generic import RedirectView
 from lizard_ui.urls import debugmode_urlpatterns
+
 
 from .views import Root, ManagementView, CSVUploadView
 
@@ -12,8 +13,8 @@ admin.autodiscover()
 
 urlpatterns = patterns(
     '',
-    url(r'^$', redirect_to, {'url': 'api/v1'}),
-    url(r'^api$', redirect_to, {'url': 'api/v1'}),
+    url(r'^$', RedirectView.as_view(url='api/v1')),
+    url(r'^api$', RedirectView.as_view(url='api/v1')),
     url(r'^admin/', include(admin.site.urls)),
     url(r'^api/v1/$', Root.as_view()),
 

--- a/development.cfg
+++ b/development.cfg
@@ -62,7 +62,7 @@ lxml = 3.1.1
 django-cors-headers = 0.06
 pandas = 0.10.1
 pyproj = 1.9.2
-lizard-auth-client = 0.5
+lizard-auth-client = 0.5.2
 django-haystack = 2.0.0
 mr.developer = 1.30
 syseggrecipe = 1.2
@@ -121,7 +121,6 @@ cassandralib = git git@github.com:nens/cassandralib.git
 rabbitmqlib = git git@github.com:nens/rabbitmqlib.git
 tslib = git git@github.com:nens/tslib.git
 django-rest-framework = git git@github.com:tomchristie/django-rest-framework.git
-lizard-auth-client = git git@github.com:lizardsystem/lizard-auth-client.git
 ddsc-logging = git git@github.com:ddsc/ddsc-logging.git
 ddsc-opendap = git git@github.com:ddsc/ddsc-opendap.git
 


### PR DESCRIPTION
...replaced deprecated redirect_to view with class-based RedirectView
Lizard-auth-client checkout isn't needed anymore.

Volgens mij is ddsc-api nu klaar voor Django 1.5.4 (and dat helpt met PostGIS 2, en wat andere bugs).
