### PR TITLE
Further pinning of 'stable' versions.

### DIFF
--- a/development.cfg
+++ b/development.cfg
@@ -24,28 +24,18 @@ parts =
 
 develop = .
 auto-checkout =
-    lizard-security
-    cassandralib
     dikedata-api
     ddsc-opendap
-    rabbitmqlib
-    tslib
     ddsc-site
     ddsc-core
-    ddsc-logging
 eggs =
     ddsc-api
 # BYRMAN: keep the following list in sync with auto-checkout as a workaround:
 # https://mail.python.org/pipermail/distutils-sig/2014-April/024126.html
-    lizard-security
-    cassandralib
     dikedata-api
     ddsc-opendap
-    rabbitmqlib
-    tslib
     ddsc-site
     ddsc-core
-    ddsc-logging
 
 
 [versions]
@@ -66,6 +56,11 @@ lizard-auth-client = 0.5.2
 django-haystack = 2.0.0
 mr.developer = 1.30
 syseggrecipe = 1.2
+cassandralib = 0.6
+ddsc-logging = 0.1.1
+tslib = 0.0.4
+lizard-security = ddsc-1.0
+rabbitmqlib = 0.4
 
 # Pinning the following dependencies to the versions currently
 # in use on the production server (as of 2014-04-08):
@@ -77,14 +72,14 @@ Genshi = 0.7  # Pydap==3.1.1
 cssselect = 0.9.1  # ddsc-site==0.1dev
 django-filter = 0.7  # ddsc-site==0.1dev, dikedata-api==0.2.dev0
 geopy = 0.98  # ddsc-site==0.1dev
-itsdangerous = 0.23  # lizard-auth-client==0.5
-pika = 0.9.13  # ddsc-logging==0.1.2.dev0, rabbitmqlib==0.5.dev0
-pycassa = 1.11.0  # cassandralib==0.7.dev0
+itsdangerous = 0.23  # lizard-auth-client==0.5.2
+pika = 0.9.13  # ddsc-logging==0.1.1
+pycassa = 1.11.0  # cassandralib==0.6
 pysolr = 3.2.0  # ddsc-site==0.1dev
 python-magic = 0.4.6  # ddsc-api==0.5.dev0, ddsc-core==1.1.dev0
 thrift = 0.9.1  # pycassa==1.11.0
 uuid = 1.30  # dikedata-api==0.2.dev0
-xmltodict = 0.8.5  # tslib==0.0.5.dev0
+xmltodict = 0.8.5  # tslib==0.0.4
 
 # Reported by buildout-versions:
 


### PR DESCRIPTION
Pinned libraries to the versions used in production.
