### PR TITLE
Upgrade treebeard to version 2.0 for Django 1.5 compatibility.

### DIFF
--- a/development.cfg
+++ b/development.cfg
@@ -43,6 +43,7 @@ eggs =
 # development egg, you really need to un-pin it here.
 ddsc-api =
 Django = 1.5.4
+django-treebeard = 2.0
 djangorestframework = 2.3.6
 sitesetup = 0.14
 lizard-wms = 1.24


### PR DESCRIPTION
The django-treebeard version we were using, 1.61 (via KGS), is not compatible with Django 1.5. Version 2.0 supports Django 1.5 and seems to be backwards compatible. See changelog: https://tabo.pe/projects/django-treebeard/docs/tip/changes.html.
